### PR TITLE
Removed visible comment + fixed sentence structure

### DIFF
--- a/components/sections.vue
+++ b/components/sections.vue
@@ -175,8 +175,7 @@
             We believe that communication should be private and no third party
             should be able to intercept and read the content of it. That’s why
             Fosscord is end-to-end encrypted based on the concept “don’t trust
-            the server”. (If you setup HTTPS)
-            // im going to make a docs page about this!
+            the server” (If you setup HTTPS).
           </div>
           <!-- <div class="mb-30 mb-md-0 d-sm-flex align-items-center buttons">
             <NuxtLink


### PR DESCRIPTION
I noticed when reading the website today that I could see what seems to be comment and that the text inside the brackets was outside of the sentence. I am not familiar with vue so I am unsure why the comment is displaying since it seems to use the correct syntax. Feel free to re-comment with the proper syntax if you are able to.