### PR TITLE
Made client button more prominent.

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -37,6 +37,19 @@ body {
 	margin-bottom: 50px;
 }
 
+#join_button {
+	padding-top: 20px;
+	padding-bottom: 20px;
+	padding-left: 50px;
+	padding-right: 50px;
+	background-color: #0185ff;
+	border: thick solid #0185ff;
+	border-radius: 20px;
+	font-size: 36px;
+	color: white !important;
+	text-decoration: none;
+}
+
 @media only screen and (max-width: 600px) {
 	#logo {
 		max-width: 100%;
@@ -54,3 +67,4 @@ a:visited {
 	gap: 20px;
 	flex-wrap: wrap;
 }
+

--- a/index.html
+++ b/index.html
@@ -24,13 +24,15 @@
 				src="https://raw.githubusercontent.com/spacebarchat/spacebarchat/master/branding/svg/Spacebar__Logo-Blue.svg"
 				alt="Spacebar logo">
 			<div id="text">
+				<a id="join_button" href="https://fermi.chat/app">Join the action!</a>
+				<br/>
 				<p>Spacebar is a free and open source, full stack reverse engineering and reimplementation of Discord.
 				</p>
 				<p>It's a communication platform you're already familiar with.</p>
 
 				<div class="links">
 					<a href="https://docs.spacebar.chat" target="_blank">Docs</a>
-					<a href="https://fermi.chat/app" target="_blank">App</a>
+					<!--<a href="https://fermi.chat/app" target="_blank">App</a>-->
 					<a href="https://github.com/spacebarchat" target="_blank">Github</a>
 					<a href="https://discord.gg/ZrnGQP6p3d" target="_blank">Discord</a>
 					<a href="https://matrix.to/#/!OovtSBQaxNmuBWlQzV:feline.support" target="_blank">Matrix</a>


### PR DESCRIPTION
It was suggested to make the button to open a Spacebar client more prominent on the landing page because some users were struggling to figure out how to open the app. I commented the original client button out. Element provides a list of clients and descriptions on what they intend to achieve to help chose the best one. I think we could do something similar later on while keeping Fermi as default. Feel free to make any alterations if needed.